### PR TITLE
Webpack.config tweaked to enable webpack --watch under Windows

### DIFF
--- a/1-basic-react/webpack.config.js
+++ b/1-basic-react/webpack.config.js
@@ -3,7 +3,7 @@ var webpack = require('webpack');
 var path = require('path');
 
 module.exports = {
-  context: path.join(__dirname, "/src"),
+  context: path.join(__dirname, "src"),
   devtool: debug ? "inline-sourcemap" : null,
   entry: "./js/client.js",
   module: {

--- a/1-basic-react/webpack.config.js
+++ b/1-basic-react/webpack.config.js
@@ -1,8 +1,9 @@
 var debug = process.env.NODE_ENV !== "production";
 var webpack = require('webpack');
+var path = require('path');
 
 module.exports = {
-  context: __dirname + "/src",
+  context: path.join(__dirname, "/src"),
   devtool: debug ? "inline-sourcemap" : null,
   entry: "./js/client.js",
   module: {


### PR DESCRIPTION
Under windows the "webpack --watch" and the "webpack-dev-server --hot" fail to rebuild the code after file changes due to the different path separator.  This tweak to the webpack config fixes this.
Tested on Windows 10.