### PR TITLE
Swapping around plugins

### DIFF
--- a/1-basic-react/webpack.config.js
+++ b/1-basic-react/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
         loader: 'babel-loader',
         query: {
           presets: ['react', 'es2015', 'stage-0'],
-          plugins: ['react-html-attrs', 'transform-class-properties', 'transform-decorators-legacy'],
+          plugins: ['react-html-attrs', 'transform-decorators-legacy', 'transform-class-properties'],
         }
       }
     ]


### PR DESCRIPTION
swapped 'transform-decorators-legacy' and 'transform-class-properties' as when the 'decorator' goes after 'class' plugin then the ES7 decorators seem to get ignored. i ran into this issue once i started using decorators in mobx tutorial (which has them the correct way around)