### PR TITLE
Fix active class highlighting

### DIFF
--- a/2-react-router/src/index.html
+++ b/2-react-router/src/index.html
@@ -14,6 +14,7 @@
   <!-- Custom Fonts -->
   <link href="font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
   <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">
+  <link href="overrides.css" rel="stylesheet">
 </head>
 
 <body>

--- a/2-react-router/src/js/components/layout/Nav.js
+++ b/2-react-router/src/js/components/layout/Nav.js
@@ -15,7 +15,7 @@ export default class Nav extends React.Component {
   }
 
   render() {
-    const { location } = this.props;
+    // const { location } = this.props;
     const { collapsed } = this.state;
     // const featuredClass = location.pathname === "/" ? "active" : "";
     // const archivesClass = location.pathname.match(/^\/archives/) ? "active" : "";
@@ -35,14 +35,14 @@ export default class Nav extends React.Component {
           </div>
           <div class={"navbar-collapse " + navClass} id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav">
-              <li activeClassName="active" onlyActiveOnIndex={true}>
-                <IndexLink to="/" onClick={this.toggleCollapse.bind(this)}>Featured</IndexLink>
+              <li>
+                <IndexLink to="/" activeClassName="active" onClick={this.toggleCollapse.bind(this)}>Featured</IndexLink>
               </li>
-              <li activeClassName="active">
-                <Link to="archives" onClick={this.toggleCollapse.bind(this)}>Archives</Link>
+              <li>
+                <Link to="archives" activeClassName="active" onClick={this.toggleCollapse.bind(this)}>Archives</Link>
               </li>
-              <li activeClassName="active">
-                <Link to="settings" onClick={this.toggleCollapse.bind(this)}>Settings</Link>
+              <li>
+                <Link to="settings" activeClassName="active" onClick={this.toggleCollapse.bind(this)}>Settings</Link>
               </li>
             </ul>
           </div>

--- a/2-react-router/src/overrides.css
+++ b/2-react-router/src/overrides.css
@@ -1,0 +1,4 @@
+.navbar-inverse .navbar-nav a.active {
+  color: #ffffff;
+  background-color: #022f5a;
+}


### PR DESCRIPTION
1. react will only interpret activeClassName to apply class="what-you-provided" if found on Link components
2. bootstrap will only look for class="active" on li elements, hence the overrides.css
3. in order to prevent wrong highlighting one can provide onlyActiveOnIndex or use IndexLink; second seemed cleaner

TODO: there are still problems with active highlighting when using back browser button...