### PR TITLE
stringify tweet text

### DIFF
--- a/5-redux-react/src/js/components/Layout.js
+++ b/5-redux-react/src/js/components/Layout.js
@@ -27,7 +27,7 @@ export default class Layout extends React.Component {
       return <button onClick={this.fetchTweets.bind(this)}>load tweets</button>
     }
 
-    const mappedTweets = tweets.map(tweet => <li>{tweet.text}</li>)
+    const mappedTweets = tweets.map(tweet => <li>{String(tweet.text)}</li>)
 
     return <div>
       <h1>{user.name}</h1>


### PR DESCRIPTION
If one tweet text is not a string but an object, React will fail to render mappedTweets. For example, a problematic tweet
{"text":{"tweet":"abc"},"id":"123"}