### PR TITLE
add "es6-promise" in package.json

### DIFF
--- a/4-redux/package.json
+++ b/4-redux/package.json
@@ -14,6 +14,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
+    "es6-promise": "^4.2.2",
     "react": "^0.14.6",
     "react-dom": "^0.14.6",
     "redux": "^3.5.2",


### PR DESCRIPTION
Add the "es6-promise" dependencies in `package.json` to avoid the following error : 
`ReferenceError: Promise is not defined at webpackDevMiddleware`