### PR TITLE
loader tag has been renamed to rules in webpack

### DIFF
--- a/1-basic-react/webpack.config.js
+++ b/1-basic-react/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   devtool: debug ? "inline-sourcemap" : false,
   entry: "./js/client.js",
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.jsx?$/,
         exclude: /(node_modules|bower_components)/,


### PR DESCRIPTION
Using loader tag shows up error, since it has been renamed to rules