### PR TITLE
Babel 6 issue

### DIFF
--- a/1-basic-react/package.json
+++ b/1-basic-react/package.json
@@ -5,7 +5,7 @@
   "main": "webpack.config.js",
   "dependencies": {
     "babel-core": "^6.17.0",
-    "babel-loader": "^6.2.0",
+    "babel-loader": "^7.1.5",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-react-html-attrs": "^2.0.0",
     "babel-plugin-transform-class-properties": "^6.3.13",


### PR DESCRIPTION
When running webpack --watch,babel 6 shows issue "Cannot read property 'babel' of undefined",
updating it fixes the problem.